### PR TITLE
Fix docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,6 @@
 using ParetoSmooth
 using Documenter
 
-DocMeta.setdocmeta!(ParetoSmooth, :DocTestSetup, :(using ParetoSmooth); recursive=true)
-
 makedocs(;
     modules=[ParetoSmooth],
     authors="Carlos Parada <paradac@carleton.edu>",
@@ -10,18 +8,18 @@ makedocs(;
     sitename="ParetoSmooth.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://TuringLang.github.io/ParetoSmooth.jl",
+        canonical="https://turinglang.github.io/ParetoSmooth.jl",
         assets=String[],
     ),
     pages=[
         "Home" => "index.md",
     ],
+    strict=true,
+    checkdocs=:exports,
 )
 
-if get(ENV, "CI", "false") == "true"
-    deploydocs(;
-        repo="github.com/TuringLang/ParetoSmooth.jl",
-        push_preview=true,
-    )
-end
-
+deploydocs(;
+    repo="github.com/TuringLang/ParetoSmooth.jl",
+    push_preview=true,
+    devbranch="main",
+)


### PR DESCRIPTION
One has to set the deployed branch explicitly if it is not called master. I also removed some things that seemed unnecessary and added stricter checks for missing documentation (it will error if not everything is documented that is exported; in this case I'll comment it for now but it would be good to fix it).

I assume it fixes https://github.com/TuringLang/ParetoSmooth.jl/issues/45