### PR TITLE
Avoid computing ess and sup_ess in `psis`

### DIFF
--- a/src/ImportanceSampling.jl
+++ b/src/ImportanceSampling.jl
@@ -229,7 +229,7 @@ function psis!(is_ratios::AbstractVector{<:Real}, tail_length::Integer)
     # unsort the ratios to their original position:
     invpermute!(is_ratios, last.(ratio_index))
 
-    return ξ::T
+    return ξ
 end
 
 


### PR DESCRIPTION
This PR makes `ess` and `sup_ess` properties of `Psis` instead of fields, so that they are lazily computed only if necessary instead of in each `psis` call. It also fixes some potential issues where variables of one type are then aliased to have a different type, which may cause issues with type inference (it did in older Julia versions at least) and also makes the code more complicated.