### PR TITLE
Remove all uses of Tullio.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParetoSmooth"
 uuid = "a68b5a21-f429-434e-8bfa-46b447300aac"
 authors = ["Carlos Parada <cdp49@cam.ac.uk>"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 
 [compat]
 AxisKeys = "0.1.18"
@@ -26,7 +25,6 @@ NamedDims = "0.2.35"
 PrettyTables = "1.1.0"
 Requires = "1.1.3"
 StatsBase = "0.33.10"
-Tullio = "0.3.0"
 julia = "1.6"
 
 [extras]

--- a/src/ESS.jl
+++ b/src/ESS.jl
@@ -51,7 +51,7 @@ See `?relative_eff` to calculate `r_eff`.
 function psis_ess(
     weights::AbstractMatrix{T}, r_eff::AbstractVector{T}
 ) where T<:Real
-    exp_entropy = zeros(weights, size(weights, 1))
+    exp_entropy = zeros(T, size(weights, 1))
     @inline for y = axes(weights, 2), x = axes(weights, 1)
         exp_entropy[x] -= xlogx(weights[x, y])
     end

--- a/src/ESS.jl
+++ b/src/ESS.jl
@@ -52,7 +52,7 @@ function psis_ess(
     weights::AbstractMatrix{T}, r_eff::AbstractVector{T}
 ) where T<:Real
     exp_entropy = zeros(T, size(weights, 1))
-    @inline for y = axes(weights, 2), x = axes(weights, 1)
+    @inbounds for y = axes(weights, 2), x = axes(weights, 1)
         exp_entropy[x] -= xlogx(weights[x, y])
     end
     for i = eachindex(exp_entropy)

--- a/src/ESS.jl
+++ b/src/ESS.jl
@@ -1,5 +1,4 @@
 using MCMCDiagnosticTools
-using Tullio
 
 export relative_eff, psis_ess, sup_ess
 
@@ -52,7 +51,13 @@ See `?relative_eff` to calculate `r_eff`.
 function psis_ess(
     weights::AbstractMatrix{T}, r_eff::AbstractVector{T}
 ) where T<:Real
-    @tullio exp_entropy[x] := - xlogx(weights[x, y]) |> exp
+    exp_entropy = zeros(weights, size(weights, 1))
+    @inline for y = axes(weights, 2), x = axes(weights, 1)
+        exp_entropy[x] -= xlogx(weights[x, y])
+    end
+    for i = eachindex(exp_entropy)
+        exp_entropy[i] = exp_inline(exp_entropy[i])
+    end
     return r_eff .* exp_entropy
 end
 

--- a/src/ImportanceSampling.jl
+++ b/src/ImportanceSampling.jl
@@ -1,5 +1,3 @@
-using Tullio
-
 const LIKELY_ERROR_CAUSES = """
 1. Incorrect inputs -- check your program for bugs. If you provided an `r_eff` argument,
 double check it is correct.
@@ -163,8 +161,10 @@ function psis(
             tail_length=tail_length[i], log_weights = false
         )
     end
-
-    @tullio norm_const[i] := weights[i, j, k]
+    norm_const = zeros(eltype(weights), size(weights, 1))
+    @inbounds for k = axes(weights, 3), j = axes(weights, 2), i = axes(weights, 1)
+        norm_const[i] += weights[i, j, k]
+    end
     @. weights = weights / norm_const
 
     

--- a/src/LeaveOneOut.jl
+++ b/src/LeaveOneOut.jl
@@ -189,7 +189,7 @@ function loo_from_psis(log_likelihood::AbstractArray{<:Real, 3}, psis_object::Ps
 
     table = _generate_loo_table(pointwise)
     
-    gmpd = exp.(table(column=:mean, statistic=:cv_elpd))
+    gmpd = exp_inline.(table(column=:mean, statistic=:cv_elpd))
 
     mcse = sum(abs2, pointwise_mcse) |> sqrt
     return PsisLoo(table, pointwise, psis_object, gmpd, mcse)
@@ -250,7 +250,7 @@ end
 
 
 function _calc_mcse(weights, log_likelihood, pointwise_loo, r_eff)
-    pointwise_gmpd = exp.(pointwise_loo)
+    pointwise_gmpd = exp_inline.(pointwise_loo)
     pointwise_var = zeros(eltype(log_likelihood), size(log_likelihood, 1))
     @inbounds for k = axes(weights,3), j = axes(weights,2), i = axes(weights,1)
         pointwise_var[i] += (weights[i,j,k] * (exp_inline(log_likelihood[i,j,k]) - pointwise_gmpd[i]))^2

--- a/src/LeaveOneOut.jl
+++ b/src/LeaveOneOut.jl
@@ -218,7 +218,7 @@ function _generate_loo_table(pointwise::AbstractMatrix{<:Real})
 
     # calculate the sample expectation for the total score
     to_sum = pointwise([:cv_elpd, :naive_lpd, :p_eff])
-    avgs = similar(eltype(to_sum), size(to_sum, 2))
+    avgs = similar(to_sum, size(to_sum, 2))
     @inbounds for j = axes(to_sum,2)
         avg = zero(eltype(to_sum))
         @simd for i = axes(to_sum,1)

--- a/src/LeaveOneOut.jl
+++ b/src/LeaveOneOut.jl
@@ -156,7 +156,7 @@ function loo_from_psis(log_likelihood::AbstractArray{<:Real, 3}, psis_object::Ps
 
     T = eltype(log_likelihood)
     pointwise_loo = zeros(T, size(log_likelihood, 1))
-    pointwise_naive = zeros(pointwise_loo)
+    pointwise_naive = zeros(T, size(log_likelihood, 1))
     for k = axes(weights,3), j = axes(weights,2), i = axes(weights,1)
         pointwise_loo[i] += weights[i,j,k] * exp_inline(log_likelihood[i,j,k])
         pointwise_naive[i] += exp_inline(log_likelihood[i,j,k]-log_count)

--- a/src/LeaveOneOut.jl
+++ b/src/LeaveOneOut.jl
@@ -157,7 +157,7 @@ function loo_from_psis(log_likelihood::AbstractArray{<:Real, 3}, psis_object::Ps
     T = eltype(log_likelihood)
     pointwise_loo = zeros(T, size(log_likelihood, 1))
     pointwise_naive = zeros(T, size(log_likelihood, 1))
-    for k = axes(weights,3), j = axes(weights,2), i = axes(weights,1)
+    @inbounds for k = axes(weights,3), j = axes(weights,2), i = axes(weights,1)
         pointwise_loo[i] += weights[i,j,k] * exp_inline(log_likelihood[i,j,k])
         pointwise_naive[i] += exp_inline(log_likelihood[i,j,k]-log_count)
     end
@@ -165,7 +165,7 @@ function loo_from_psis(log_likelihood::AbstractArray{<:Real, 3}, psis_object::Ps
         pointwise_loo[i] = log(pointwise_loo[i])
         pointwise_naive[i] = log(pointwise_naive[i])
     end
-    for i = eachindex(pointwise_loo)
+    @inbounds for i = eachindex(pointwise_loo)
         acc_loo = zero(eltype(pointwise_loo))
         acc_naive = zero(eltype(pointwise_naive))
         for j = axes(weights,2), k = axes(weights,3)
@@ -252,7 +252,7 @@ end
 function _calc_mcse(weights, log_likelihood, pointwise_loo, r_eff)
     pointwise_gmpd = exp.(pointwise_loo)
     pointwise_var = zeros(eltype(log_likelihood), size(log_likelihood, 1))
-    for k = axes(weights,3), j = axes(weights,2), i = axes(weights,1)
+    @inbounds for k = axes(weights,3), j = axes(weights,2), i = axes(weights,1)
         pointwise_var[i] += (weights[i,j,k] * (exp_inline(log_likelihood[i,j,k]) - pointwise_gmpd[i]))^2
     end
     # If MCMC draws follow a log-normal distribution, then their log has this std. error:

--- a/src/ParetoSmooth.jl
+++ b/src/ParetoSmooth.jl
@@ -16,6 +16,12 @@ function __init__()
 
 end
 
+if VERSION >= v"1.8"
+@inline exp_inline(x) = @inline exp(x)
+else
+const exp_inline = exp
+end
+
 include("AbstractCV.jl")
 include("ESS.jl")
 include("GPD.jl")

--- a/src/ParetoSmooth.jl
+++ b/src/ParetoSmooth.jl
@@ -16,7 +16,7 @@ function __init__()
 
 end
 
-if VERSION >= v"1.8"
+@static if VERSION >= v"1.8"
 @inline exp_inline(x) = @inline exp(x)
 else
 const exp_inline = exp

--- a/test/tests/TuringTests.jl
+++ b/test/tests/TuringTests.jl
@@ -46,7 +46,6 @@ using Distributions, Random, MCMCChains, Turing
     @test size(pw_lls_turing) == (50, 1000, 12)
     # test that sum of pointwise log likelihoods equals sum of log likelihoods
     turing_samples = Array(Chains(chain, :parameters).value)
-    # make this more terse with @tulliosum or other method later
     LL = 0.0
     n_samples, n_parms, n_chains = size(turing_samples)
     for s in 1:n_samples


### PR DESCRIPTION
The motivation for this is that package load time is super linear as a function of number of packages/amount of code loaded. For this reason, large packages with many dependencies can reach truly extreme load times.
Not all packages display this problem, but Tullio
does. `@time_imports`, for example, shows:
```julia
  14424.8 ms  Tullio 0.30% compilation time
     56.5 ms  ParetoSmooth 53.39% compilation time (15% recompilation)
```
For a large package using `ParetoSmooth`. We would like to continue using `ParetoSmooth`, but without taking this hit from `Tullio`.

Before, the overall load time
```
273.378616 seconds (343.75 M allocations: 20.100 GiB, 48.79% gc time, 10.88% compilation time: 23% of which was recompilation)
```
After
```
262.427614 seconds (330.26 M allocations: 19.477 GiB, 47.88% gc time, 12.00% compilation time: 22% of which was recompilation)
```