### PR TITLE
use extensions instead of Requires on 1.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,9 +17,19 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
+[weakdeps]
+MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
+DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8"
+
+[extensions]
+ParetoSmoothDynamicPPLExt = ["DynamicPPL", "MCMCChains"]
+ParetoSmoothMCMCChainsExt = "MCMCChains"
+
 [compat]
 AxisKeys = "0.1.18, 0.2"
+DynamicPPL = "0.22"
 LogExpFunctions = "0.3"
+MCMCChains = "5"
 MCMCDiagnosticTools = "0.1.0"
 NamedDims = "0.2.35, 1"
 PrettyTables = "2.1,2.2"
@@ -28,6 +38,8 @@ StatsBase = "0.33.10"
 julia = "1.6"
 
 [extras]
+MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
+DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/ext/ParetoSmoothMCMCChainsExt.jl
+++ b/ext/ParetoSmoothMCMCChainsExt.jl
@@ -1,11 +1,14 @@
-using .MCMCChains
-export pointwise_log_likelihoods
+module ParetoSmoothMCMCChainsExt
 
+if isdefined(Base, :get_extension)
+    using ParetoSmooth
+    using MCMCChains
+else
+    using ..ParetoSmooth
+    using ..MCMCChains
+end
 
-const CHAINS_ARG = """
-`chains::Chains`: A chain object from MCMCChains.
-"""
-
+using ParetoSmooth: LIKELIHOOD_FUNCTION_ARG, DATA_ARG, CHAINS_ARG, ARGS, KWARGS
 
 """
     pointwise_log_likelihoods(ll_fun::Function, chains::Chains, data)
@@ -21,7 +24,7 @@ Compute the pointwise log likelihoods.
   - `Array`: a three dimensional array of pointwise log-likelihoods. Dimensions are ordered
     as `[data, step, chain]`.
 """
-function pointwise_log_likelihoods(
+function ParetoSmooth.pointwise_log_likelihoods(
     ll_fun::Function, chain::Chains, data::AbstractVector; kwargs...
 )
     samples = Chains(chain, :parameters).value
@@ -31,10 +34,10 @@ end
 
 """
     function psis_loo(
-        ll_fun::Function, 
-        chain::Chains, 
-        data, 
-        args...; 
+        ll_fun::Function,
+        chain::Chains,
+        data,
+        args...;
         kwargs...
     ) -> PsisLoo
 
@@ -51,7 +54,7 @@ score from an MCMCChains object.
 
 See also: [`psis_loo`](@ref), [`loo`](@ref), [`PsisLoo`](@ref).
 """
-function psis_loo(ll_fun::Function, chain::Chains, data::AbstractVector, args...; kwargs...)
+function ParetoSmooth.psis_loo(ll_fun::Function, chain::Chains, data::AbstractVector, args...; kwargs...)
     pointwise_log_likes = pointwise_log_likelihoods(ll_fun, chain, data)
     return psis_loo(pointwise_log_likes, args...; kwargs...)
 end
@@ -71,7 +74,9 @@ Implements Pareto-smoothed importance sampling (PSIS) based on MCMCChain object.
 
 See also: [`psis`](@ref), [`psis_loo`](@ref), [`PsisLoo`](@ref).
 """
-function psis(ll_fun::Function, chain::Chains, data::AbstractVector, args...; kwargs...)
+function ParetoSmooth.psis(ll_fun::Function, chain::Chains, data::AbstractVector, args...; kwargs...)
     pointwise_log_likes = pointwise_log_likelihoods(ll_fun, chain, data)
     return psis(-pointwise_log_likes, args...; kwargs...)
+end
+
 end

--- a/src/InternalHelpers.jl
+++ b/src/InternalHelpers.jl
@@ -4,6 +4,10 @@ belongs to. For instance, `chain_index[step]` should return `2` if `log_likeliho
 belongs to the second chain.
 """
 
+const CHAINS_ARG = """
+`chains::Chains`: A chain object from MCMCChains.
+"""
+
 const DATA_ARG = """
 `data`: An array of data points used to estimate the parameters of the model.
 """
@@ -21,8 +25,8 @@ or if all posterior samples were drawn from a single chain.
 """
 
 const R_EFF_DOC = """
-`r_eff::AbstractVector`: An (optional) vector of relative effective sample sizes used in ESS 
-calculations. If left empty, calculated automatically using the FFTESS method from 
+`r_eff::AbstractVector`: An (optional) vector of relative effective sample sizes used in ESS
+calculations. If left empty, calculated automatically using the FFTESS method from
 InferenceDiagnostics.jl. See `relative_eff` to calculate these values.
 """
 

--- a/src/ParetoSmooth.jl
+++ b/src/ParetoSmooth.jl
@@ -1,19 +1,18 @@
 module ParetoSmooth
-using Requires
 
+if !isdefined(Base, :get_extension)
+    using Requires
+end
+
+@static if !isdefined(Base, :get_extension)
 function __init__()
-    chains=false
-    @require MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d" begin 
-        include("MCMCChainsHelpers.jl")
-        chains=true
+    @require MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d" begin
+        include("../ext/ParetoSmoothMCMCChainsExt.jl")
     end
-    @require Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0" begin
-        if !chains
-            include("MCMCChainsHelpers.jl")
-        end
-        include("TuringHelpers.jl")
-    end 
-
+    @require DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8" begin
+        include("../ext/ParetoSmoothDynamicPPLExt.jl")
+    end
+end
 end
 
 @static if VERSION >= v"1.8"


### PR DESCRIPTION
This uses the new extension system in Julia 1.9 to avoid having to use Requires.jl which has a few issues.

I was a bit confused by the use of Requires in this package:

- The `export`s in the requiered files. These are already exported by ParetoSmooth so they don't do anything.
- The `chains=false` in `__init__`. MCMCChains is a dependency of Turing so it doesn't seem this should do anything
- TuringHelpers.jl only seems to use DynamicPPL, so why is it triggered on Turing?

I changed this to how I think it is "reasonable" and tests seem to pass but please give it another set of eyes.