### PR TITLE
Update [compat] entries for Documenter and Statistics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ MCMCDiagnosticTools = "0.3.2"
 NamedDims = "0.2.35, 1"
 PrettyTables = "2.1,2.2"
 Requires = "1.1.3"
-Statistics = "1"
+Statistics = "<0.0.1, 1"
 StatsBase = "0.33.10, 0.34"
 julia = "1.6"
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.27, 1"
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,6 @@ makedocs(;
         "Home" => "index.md",
         "Using with Turing" => "turing.md",
     ],
-    strict=true,
     checkdocs=:exports,
 )
 


### PR DESCRIPTION
These were outdated and causing downgrades for a few other packages, including Turing.

Closes #88.
Closes #89.